### PR TITLE
Approve user console command added

### DIFF
--- a/api/src/Command/ApproveBulkUsersCommand.php
+++ b/api/src/Command/ApproveBulkUsersCommand.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace App\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\ArrayInput;
+use App\Entity\User;
+use App\Entity\Ticket;
+use App\Entity\TicketType;
+use App\Entity\Event;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Ramsey\Uuid\Uuid;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
+
+class ApproveBulkUsersCommand extends Command
+{
+    // the name of the command (the part after "bin/console")
+    protected static $defaultName = 'app:user:approve_bulk';
+    private $entityManager;
+    private $refreshTokenManager;
+    /** @var User $user */
+    private $users;
+    private $delete;
+
+    public function __construct(EntityManagerInterface $entityManager, RefreshTokenManagerInterface $refreshTokenManager)
+    {
+        $this->entityManager = $entityManager;
+        $this->refreshTokenManager = $refreshTokenManager;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Approve new user accounts.')
+            ->setHelp('This command allows you to approve users.')
+        ;
+    }
+
+// ...
+    public function interact(InputInterface $input, OutputInterface $output)
+    {
+        // Get all users from db :(
+        $users = $this->entityManager->getRepository(User::class)->findAll();
+        $this->users = [];
+        
+        $helper = $this->getHelper('question');
+
+        foreach($users as $user) {
+            if( $user->getRoles() === [] ){     
+                $output->writeln(sprintf("%s, %s - %s - %s", $user->getLastName(), $user->getFirstName(), $user->getServiceNumber(), $user->getEmail()));
+                $question = new ChoiceQuestion("Please select an option (defaults to skip)", ['skip', 'approve', 'reject'], 0);
+                $question->setErrorMessage('Option %s is invalid');
+                $response = $helper->ask($input, $output, $question);
+                
+                switch($response) {
+                    case 'approve':
+                        array_push($this->users, $user);
+                        break;
+                    case 'deny':
+                        array_push($this->delete, $user);
+                        break;
+                }
+            }
+        }
+        return Command::SUCCESS;
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $command = $this->getApplication()->find('app:user:approve');
+        
+
+        foreach($this->users as $user) {
+            $arguments = [
+                'uid' => $user->getId(),
+                'serving' => 'Y',
+                'retired' => 'N'
+            ];
+
+            $argInput = new ArrayInput($arguments);
+            $returnCode = $command->run($argInput, $output);
+        }
+
+        return Command::SUCCESS;
+    }
+
+}

--- a/api/src/Command/ApproveUserCommand.php
+++ b/api/src/Command/ApproveUserCommand.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use App\Entity\User;
+use App\Entity\Ticket;
+use App\Entity\TicketType;
+use App\Entity\Event;
+use Symfony\Component\Console\Question\Question;
+use Ramsey\Uuid\Uuid;
+use Gesdinet\JWTRefreshTokenBundle\Model\RefreshTokenManagerInterface;
+
+class ApproveUserCommand extends Command
+{
+    // the name of the command (the part after "bin/console")
+    protected static $defaultName = 'app:user:approve';
+    private $entityManager;
+    private $refreshTokenManager;
+    /** @var User $user */
+    private $user;
+
+    public function __construct(EntityManagerInterface $entityManager, RefreshTokenManagerInterface $refreshTokenManager)
+    {
+        $this->entityManager = $entityManager;
+        $this->refreshTokenManager = $refreshTokenManager;
+
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setDescription('Approve user account.')
+            ->setHelp('This command allows you to approve users.')
+            ->addArgument('uid', InputArgument::OPTIONAL, 'User ID.')
+            ->addArgument('serving', InputArgument::OPTIONAL, 'Serving')
+            ->addArgument('retired', InputArgument::OPTIONAL, 'Retired')
+        ;
+    }
+
+// ...
+    public function interact(InputInterface $input, OutputInterface $output)
+    {
+        $this->user = $this->entityManager->getRepository(User::class)->find($input->getArgument('uid'));
+        if ($this->user) {
+            return Command::SUCCESS;
+        }
+        else{
+            $output->writeln("User not found");
+        }
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $roles = [];
+        
+        array_push($roles, 'ROLE_MEMBER');
+        array_push($roles, 'ROLE_USER');
+
+        if($input->getArgument('serving') === 'Y') {
+            array_push($roles, 'ROLE_SERVING');
+        }
+        else if($input->getArgument('retired') === 'Y') {
+            array_push($roles, 'ROLE_RETIRED');
+        }
+
+        $this->user->setRoles($roles);
+        
+
+        $ticket = new Ticket;
+        $ticket->setTicketType( $this->entityManager->getRepository(TicketType::class)->find(15) );
+        $ticket->setUuid(Uuid::uuid4());
+        $ticket->setOwner($this->user);
+        $ticket->setEvent( $this->entityManager->getRepository(Event::class)->find(1) );
+
+        $ticket->setRank("N/A");
+        $ticket->setFirstname("N/A");
+        $ticket->setLastname("N/A");
+        $ticket->setDietary("N/A");
+        $this->entityManager->persist($ticket);
+        
+        $this->entityManager->flush();
+
+        return Command::SUCCESS;
+    }
+
+}


### PR DESCRIPTION
Two commands added:

app:user:approve <uid> <serving> <retired>
app:user:approve_bulk

Second command calls first command for each user (with option to skip).  Currently only configured for 'serving' members.  For retired members, use app:user:approve.