### PR TITLE
Change error logging level

### DIFF
--- a/api/config/packages/dev/monolog.yaml
+++ b/api/config/packages/dev/monolog.yaml
@@ -25,7 +25,7 @@ monolog:
     handlers:
         main:
             type: fingers_crossed
-            action_level: debug
+            action_level: warning
             handler: rollbar
         #    excluded_http_codes: []
             buffer_size: 50 # How many messages should be saved? Prevent memory leaks

--- a/api/config/packages/prod/monolog.yaml
+++ b/api/config/packages/prod/monolog.yaml
@@ -2,7 +2,7 @@ monolog:
     handlers:
         main:
             type: fingers_crossed
-            action_level: debug
+            action_level: warning
             handler: rollbar
             buffer_size: 50 # How many messages should be saved? Prevent memory leaks
         rollbar:


### PR DESCRIPTION
Changes error logging from debug to warning.  When a warning occurs, the logs will include debug/info logging for that event.