### PR TITLE
Fixes for RabbitMQ image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.idea/
 !/helm/api-platform/charts/.gitignore
 /helm/api-platform/charts/*
+.DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
         protocol: udp
 
   rabbitmq:
-    image: rabbitmq:3-management-alpine
+    image: rabbitmq:3.9-management-alpine
     volumes:
       - ./../rabbitmq:/var/lib/rabbitmq:cached
     hostname: sodc_rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,6 +79,7 @@ services:
     volumes:
       - ./../rabbitmq:/var/lib/rabbitmq:cached
     hostname: sodc_rabbitmq
+    restart: unless-stopped
     ports:
       - target: 15672
         published: 15672


### PR DESCRIPTION
Auto restart of RabbitMQ, and restrict version to 3.9.