### PR TITLE
Unsubscriber

### DIFF
--- a/api/config/packages/framework.yaml
+++ b/api/config/packages/framework.yaml
@@ -7,7 +7,8 @@ framework:
     trusted_headers: ['x-forwarded-for', 'x-forwarded-proto']
     #csrf_protection: true
     #http_method_override: true
-
+    router:
+        default_uri: 'https://%env(SERVER_NAME)%'
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.
     session:

--- a/api/config/services.yaml
+++ b/api/config/services.yaml
@@ -121,7 +121,6 @@ services:
     App\DataProvider\UserDataProvider:
         bind:
             $collectionDataProvider: '@api_platform.doctrine.orm.default.collection_data_provider'
-            $itemDataProvider: '@api_platform.doctrine.orm.default.item_data_provider'
 
     App\DataProvider\EventDataProvider:
         bind:

--- a/api/migrations/Version20240802095840.php
+++ b/api/migrations/Version20240802095840.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+use Doctrine\DBAL\Types\Types;
+use Doctrine\DBAL\ParameterType;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240802095840 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Create subscription and associate with users who are subscribed';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Create the tables
+        $this->addSql('CREATE TABLE subscription (uuid UUID NOT NULL, name VARCHAR(255) NOT NULL, PRIMARY KEY(uuid))');
+        $this->addSql('COMMENT ON COLUMN subscription.uuid IS \'(DC2Type:uuid)\'');
+        $this->addSql('CREATE TABLE user_subscription (uuid UUID NOT NULL, owner_id UUID NOT NULL, subscription_id UUID NOT NULL, PRIMARY KEY(uuid))');
+        $this->addSql('CREATE INDEX IDX_EAF927517E3C61F9 ON user_subscription (owner_id)');
+        $this->addSql('CREATE INDEX IDX_EAF927519A1887DC ON user_subscription (subscription_id)');
+        $this->addSql('COMMENT ON COLUMN user_subscription.uuid IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN user_subscription.owner_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('COMMENT ON COLUMN user_subscription.subscription_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('ALTER TABLE user_subscription ADD CONSTRAINT FK_EAF927517E3C61F9 FOREIGN KEY (owner_id) REFERENCES "user" (uuid) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE user_subscription ADD CONSTRAINT FK_EAF927519A1887DC FOREIGN KEY (subscription_id) REFERENCES subscription (uuid) NOT DEFERRABLE INITIALLY IMMEDIATE');
+
+        // Create the subscription
+        $subscriptionUuid = $this->generateUuid();
+        $this->addSql('INSERT INTO subscription (uuid, name) VALUES (:uuid, :name)', [
+            'uuid' => $subscriptionUuid,
+            'name' => 'Default Subscription',
+        ], [
+            'uuid' => ParameterType::STRING,
+            'name' => ParameterType::STRING,
+        ]);
+
+        // Associate the subscription with users who have 'isSubscribed' set to true
+        $users = $this->connection->fetchAllAssociative('SELECT uuid FROM "user" WHERE is_subscribed = TRUE');
+
+        foreach ($users as $user) {
+            $userSubscriptionUuid = $this->generateUuid();
+            $this->addSql('INSERT INTO user_subscription (uuid, owner_id, subscription_id) VALUES (:uuid, :ownerId, :subscriptionId)', [
+                'uuid' => $userSubscriptionUuid,
+                'ownerId' => $user['uuid'],
+                'subscriptionId' => $subscriptionUuid,
+            ], [
+                'uuid' => ParameterType::STRING,
+                'ownerId' => ParameterType::STRING,
+                'subscriptionId' => ParameterType::STRING,
+            ]);
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Drop the tables
+        $this->addSql('ALTER TABLE user_subscription DROP CONSTRAINT FK_EAF927517E3C61F9');
+        $this->addSql('ALTER TABLE user_subscription DROP CONSTRAINT FK_EAF927519A1887DC');
+        $this->addSql('DROP TABLE subscription');
+        $this->addSql('DROP TABLE user_subscription');
+    }
+
+    private function generateUuid(): string
+    {
+        return \Ramsey\Uuid\Uuid::uuid4()->toString();
+    }
+}

--- a/api/migrations/Version20240802105841.php
+++ b/api/migrations/Version20240802105841.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240802105841 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP INDEX uniq_8d93d64951fc1c95');
+        $this->addSql('ALTER TABLE "user" DROP unsubscribe_uuid');
+        $this->addSql('ALTER INDEX idx_eaf927517e3c61f9 RENAME TO IDX_230A18D17E3C61F9');
+        $this->addSql('ALTER INDEX idx_eaf927519a1887dc RENAME TO IDX_230A18D19A1887DC');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE "user" ADD unsubscribe_uuid UUID NOT NULL');
+        $this->addSql('COMMENT ON COLUMN "user".unsubscribe_uuid IS \'(DC2Type:uuid)\'');
+        $this->addSql('CREATE UNIQUE INDEX uniq_8d93d64951fc1c95 ON "user" (unsubscribe_uuid)');
+        $this->addSql('ALTER INDEX idx_230a18d17e3c61f9 RENAME TO idx_eaf927517e3c61f9');
+        $this->addSql('ALTER INDEX idx_230a18d19a1887dc RENAME TO idx_eaf927519a1887dc');
+    }
+}

--- a/api/migrations/Version20240805060636.php
+++ b/api/migrations/Version20240805060636.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240805060636 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add optout column to subscription table and set it to true for existing records';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Add the optout column to the subscription table with a default value
+        $this->addSql('ALTER TABLE subscription ADD optout BOOLEAN DEFAULT TRUE');
+        
+        // Ensure existing records have optout set to true
+        $this->addSql('UPDATE subscription SET optout = TRUE');
+        
+        // Alter the optout column to remove the default value
+        $this->addSql('ALTER TABLE subscription ALTER COLUMN optout SET NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Remove the optout column from the subscription table
+        $this->addSql('ALTER TABLE subscription DROP optout');
+    }
+}

--- a/api/migrations/Version20240805063846.php
+++ b/api/migrations/Version20240805063846.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240805063846 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Delete all rows from bulk_notification table
+        $this->addSql('DELETE FROM user_notification');
+        $this->addSql('DELETE FROM bulk_notification');
+
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE bulk_notification ADD subscription_id UUID NOT NULL');
+        $this->addSql('ALTER TABLE bulk_notification DROP roles');
+        $this->addSql('ALTER TABLE bulk_notification DROP is_mailing');
+        $this->addSql('COMMENT ON COLUMN bulk_notification.subscription_id IS \'(DC2Type:uuid)\'');
+        $this->addSql('ALTER TABLE bulk_notification ADD CONSTRAINT FK_E55C52599A1887DC FOREIGN KEY (subscription_id) REFERENCES subscription (uuid) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('CREATE INDEX IDX_E55C52599A1887DC ON bulk_notification (subscription_id)');
+        $this->addSql('ALTER TABLE subscription ALTER optout DROP DEFAULT');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE bulk_notification DROP CONSTRAINT FK_E55C52599A1887DC');
+        $this->addSql('DROP INDEX IDX_E55C52599A1887DC');
+        $this->addSql('ALTER TABLE bulk_notification ADD roles TEXT NOT NULL');
+        $this->addSql('ALTER TABLE bulk_notification ADD is_mailing BOOLEAN NOT NULL');
+        $this->addSql('ALTER TABLE bulk_notification DROP subscription_id');
+        $this->addSql('COMMENT ON COLUMN bulk_notification.roles IS \'(DC2Type:array)\'');
+        $this->addSql('ALTER TABLE subscription ALTER optout SET DEFAULT true');
+    }
+}

--- a/api/migrations/Version20240805063846.php
+++ b/api/migrations/Version20240805063846.php
@@ -14,22 +14,35 @@ final class Version20240805063846 extends AbstractMigration
 {
     public function getDescription(): string
     {
-        return '';
+        return 'Modify bulk_notification table to add subscription_id and set it using an existing subscription value.';
     }
 
     public function up(Schema $schema): void
     {
-        // Delete all rows from bulk_notification table
-        $this->addSql('DELETE FROM user_notification');
-        $this->addSql('DELETE FROM bulk_notification');
+        // Add the subscription_id column to the bulk_notification table allowing null values initially
+        $this->addSql('ALTER TABLE bulk_notification ADD subscription_id UUID DEFAULT NULL');
 
-        // this up() migration is auto-generated, please modify it to your needs
-        $this->addSql('ALTER TABLE bulk_notification ADD subscription_id UUID NOT NULL');
+        // Retrieve the specific subscription_id from the subscription table
+        $subscriptionId = $this->connection->fetchOne('SELECT uuid FROM subscription LIMIT 1');
+
+        // Update the bulk_notification table with this subscription_id
+        $this->addSql('UPDATE bulk_notification SET subscription_id = ?', [$subscriptionId]);
+
+        // Alter the subscription_id column to disallow null values
+        $this->addSql('ALTER TABLE bulk_notification ALTER COLUMN subscription_id SET NOT NULL');
+
+        // Drop the roles and is_mailing columns
         $this->addSql('ALTER TABLE bulk_notification DROP roles');
         $this->addSql('ALTER TABLE bulk_notification DROP is_mailing');
+
+        // Add a comment to the subscription_id column
         $this->addSql('COMMENT ON COLUMN bulk_notification.subscription_id IS \'(DC2Type:uuid)\'');
+
+        // Add foreign key constraint and index to the subscription_id column
         $this->addSql('ALTER TABLE bulk_notification ADD CONSTRAINT FK_E55C52599A1887DC FOREIGN KEY (subscription_id) REFERENCES subscription (uuid) NOT DEFERRABLE INITIALLY IMMEDIATE');
         $this->addSql('CREATE INDEX IDX_E55C52599A1887DC ON bulk_notification (subscription_id)');
+
+        // Alter the subscription table to drop the default value for the optout column
         $this->addSql('ALTER TABLE subscription ALTER optout DROP DEFAULT');
     }
 
@@ -46,3 +59,4 @@ final class Version20240805063846 extends AbstractMigration
         $this->addSql('ALTER TABLE subscription ALTER optout SET DEFAULT true');
     }
 }
+

--- a/api/src/DataPersister/UserDataPersister.php
+++ b/api/src/DataPersister/UserDataPersister.php
@@ -1,24 +1,41 @@
 <?php
+// src/DataPersister/UserDataPersister.php
 
 namespace App\DataPersister;
 
 use ApiPlatform\Core\DataPersister\DataPersisterInterface;
 use App\Entity\User;
+use App\Entity\UserSubscription;
+use App\Entity\Subscription;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
 use Symfony\Component\Security\Core\Security;
+use App\Repository\SubscriptionRepository;
+use ApiPlatform\Core\Api\IriConverterInterface;
 
 class UserDataPersister implements DataPersisterInterface
 {
     private $decoratedDataPersister;
     private $userPasswordEncoder;
     private $security;
+    private $entityManager;
+    private $subscriptionRepository;
+    private $iriConverter;
 
-    public function __construct(DataPersisterInterface $decoratedDataPersister, UserPasswordEncoderInterface $userPasswordEncoder, Security $security)
-    {
+    public function __construct(
+        DataPersisterInterface $decoratedDataPersister,
+        UserPasswordEncoderInterface $userPasswordEncoder,
+        Security $security,
+        EntityManagerInterface $entityManager,
+        SubscriptionRepository $subscriptionRepository,
+        IriConverterInterface $iriConverter
+    ) {
         $this->decoratedDataPersister = $decoratedDataPersister;
         $this->userPasswordEncoder = $userPasswordEncoder;
         $this->security = $security;
+        $this->entityManager = $entityManager;
+        $this->subscriptionRepository = $subscriptionRepository;
+        $this->iriConverter = $iriConverter;
     }
 
     public function supports($data): bool
@@ -38,12 +55,63 @@ class UserDataPersister implements DataPersisterInterface
             $data->eraseCredentials();
         }
 
+        // Handle user subscriptions update
+        if (!empty($data->getSubscriptions())) {
+            // Clear current subscriptions
+            foreach ($data->getUserSubscriptions() as $userSubscription) {
+                $this->entityManager->remove($userSubscription);
+            }
+            $data->getUserSubscriptions()->clear();
+
+            // Add new subscriptions
+            foreach ($data->getSubscriptions() as $subscriptionIri) {
+                $subscription = $this->iriConverter->getItemFromIri($subscriptionIri);
+                if ($subscription) {
+                    $userSubscription = new UserSubscription();
+                    $userSubscription->setSubscription($subscription);
+                    $userSubscription->setOwner($data);
+                    $this->entityManager->persist($userSubscription);
+                    $data->addUserSubscription($userSubscription);
+                }
+            }
+        }
+
         $data->setIsMe($this->security->getUser() === $data);
         $this->decoratedDataPersister->persist($data);
+        $this->entityManager->flush();
+
+        // Ensure the response includes the transformed subscriptions
+        $this->transformUserSubscriptions($data);
+        return $data;
     }
 
     public function remove($data)
     {
         $this->decoratedDataPersister->remove($data);
+    }
+
+    private function transformUserSubscriptions(User $user): void
+    {
+        // Fetch all subscriptions
+        $subscriptionRepo = $this->entityManager->getRepository(Subscription::class);
+        $allSubscriptions = $subscriptionRepo->findAll();
+
+        // Create a map of subscriptions the user is subscribed to
+        $subscribedSubscriptionIds = [];
+        foreach ($user->getUserSubscriptions() as $userSubscription) {
+            $subscribedSubscriptionIds[] = $userSubscription->getSubscription()->getUuid()->toString();
+        }
+
+        // Build the subscriptions array with subscription status
+        $subscriptions = [];
+        foreach ($allSubscriptions as $subscription) {
+            $subscriptions[] = [
+                'uuid' => $subscription->getUuid(),
+                'name' => $subscription->getName(),
+                'isSubscribed' => in_array($subscription->getUuid()->toString(), $subscribedSubscriptionIds)
+            ];
+        }
+
+        $user->setSubscriptions($subscriptions);
     }
 }

--- a/api/src/DataPersister/UserDataPersister.php
+++ b/api/src/DataPersister/UserDataPersister.php
@@ -59,7 +59,9 @@ class UserDataPersister implements DataPersisterInterface
         if (!empty($data->getSubscriptions())) {
             // Clear current subscriptions
             foreach ($data->getUserSubscriptions() as $userSubscription) {
-                $this->entityManager->remove($userSubscription);
+                if ($userSubscription->getSubscription()->isOptout()) {
+                    $this->entityManager->remove($userSubscription);
+                }
             }
             $data->getUserSubscriptions()->clear();
 

--- a/api/src/DataProvider/UserDataProvider.php
+++ b/api/src/DataProvider/UserDataProvider.php
@@ -1,13 +1,14 @@
 <?php
+// src/DataProvider/UserDataProvider.php
 
 namespace App\DataProvider;
 
 use ApiPlatform\Core\DataProvider\CollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\ContextAwareCollectionDataProviderInterface;
 use ApiPlatform\Core\DataProvider\DenormalizedIdentifiersAwareItemDataProviderInterface;
-use ApiPlatform\Core\DataProvider\ItemDataProviderInterface;
 use ApiPlatform\Core\DataProvider\RestrictedDataProviderInterface;
 use App\Entity\User;
+use App\Entity\Subscription;
 use Symfony\Component\Security\Core\Security;
 use Doctrine\ORM\EntityManagerInterface;
 
@@ -15,14 +16,12 @@ class UserDataProvider implements ContextAwareCollectionDataProviderInterface, D
 {
     private $collectionDataProvider;
     private $security;
-    private $itemDataProvider;
     private $entityManager;
 
-    public function __construct(CollectionDataProviderInterface $collectionDataProvider, Security $security, ItemDataProviderInterface $itemDataProvider, EntityManagerInterface $entityManager)
+    public function __construct(CollectionDataProviderInterface $collectionDataProvider, Security $security, EntityManagerInterface $entityManager)
     {
         $this->collectionDataProvider = $collectionDataProvider;
         $this->security = $security;
-        $this->itemDataProvider = $itemDataProvider;
         $this->entityManager = $entityManager;
     }
 
@@ -46,12 +45,41 @@ class UserDataProvider implements ContextAwareCollectionDataProviderInterface, D
 
     public function getItem(string $resourceClass, $id, string $operationName = null, array $context = [])
     {
-        /** @var User|null $item */
-        $item = $this->entityManager->getRepository($resourceClass)->find($id);
-        if (!$item) {
+        /** @var User|null $user */
+        $user = $this->entityManager->getRepository($resourceClass)->find($id);
+        if (!$user) {
             return null;
         }
-        $item->setIsMe($this->security->getUser() === $item);
-        return $item;
+
+        $user->setIsMe($this->security->getUser() === $user);
+
+        $this->transformUserSubscriptions($user);
+
+        return $user;
+    }
+
+    private function transformUserSubscriptions(User $user): void
+    {
+        // Fetch all subscriptions
+        $subscriptionRepo = $this->entityManager->getRepository(Subscription::class);
+        $allSubscriptions = $subscriptionRepo->findAll();
+
+        // Create a map of subscriptions the user is subscribed to
+        $subscribedSubscriptionIds = [];
+        foreach ($user->getUserSubscriptions() as $userSubscription) {
+            $subscribedSubscriptionIds[] = $userSubscription->getSubscription()->getUuid()->toString();
+        }
+
+        // Build the subscriptions array with subscription status
+        $subscriptions = [];
+        foreach ($allSubscriptions as $subscription) {
+            $subscriptions[] = [
+                'uuid' => $subscription->getUuid(),
+                'name' => $subscription->getName(),
+                'isSubscribed' => in_array($subscription->getUuid()->toString(), $subscribedSubscriptionIds)
+            ];
+        }
+
+        $user->setSubscriptions($subscriptions);
     }
 }

--- a/api/src/DataProvider/UserDataProvider.php
+++ b/api/src/DataProvider/UserDataProvider.php
@@ -11,18 +11,21 @@ use App\Entity\User;
 use App\Entity\Subscription;
 use Symfony\Component\Security\Core\Security;
 use Doctrine\ORM\EntityManagerInterface;
+use ApiPlatform\Core\Api\IriConverterInterface;
 
 class UserDataProvider implements ContextAwareCollectionDataProviderInterface, DenormalizedIdentifiersAwareItemDataProviderInterface, RestrictedDataProviderInterface
 {
     private $collectionDataProvider;
     private $security;
     private $entityManager;
+    private $iriConverter;
 
-    public function __construct(CollectionDataProviderInterface $collectionDataProvider, Security $security, EntityManagerInterface $entityManager)
+    public function __construct(CollectionDataProviderInterface $collectionDataProvider, Security $security, EntityManagerInterface $entityManager, IriConverterInterface $iriConverter)
     {
         $this->collectionDataProvider = $collectionDataProvider;
         $this->security = $security;
         $this->entityManager = $entityManager;
+        $this->iriConverter = $iriConverter;
     }
 
     public function getCollection(string $resourceClass, string $operationName = null, array $context = [])
@@ -74,7 +77,7 @@ class UserDataProvider implements ContextAwareCollectionDataProviderInterface, D
         $subscriptions = [];
         foreach ($allSubscriptions as $subscription) {
             $subscriptions[] = [
-                'uuid' => $subscription->getUuid(),
+                'uuid' => $this->iriConverter->getIriFromItem($subscription),
                 'name' => $subscription->getName(),
                 'isSubscribed' => in_array($subscription->getUuid()->toString(), $subscribedSubscriptionIds)
             ];

--- a/api/src/DataProvider/UserDataProvider.php
+++ b/api/src/DataProvider/UserDataProvider.php
@@ -76,11 +76,13 @@ class UserDataProvider implements ContextAwareCollectionDataProviderInterface, D
         // Build the subscriptions array with subscription status
         $subscriptions = [];
         foreach ($allSubscriptions as $subscription) {
-            $subscriptions[] = [
-                'uuid' => $this->iriConverter->getIriFromItem($subscription),
-                'name' => $subscription->getName(),
-                'isSubscribed' => in_array($subscription->getUuid()->toString(), $subscribedSubscriptionIds)
-            ];
+            if ($subscription->isOptout()) {
+                $subscriptions[] = [
+                    'uuid' => $this->iriConverter->getIriFromItem($subscription),
+                    'name' => $subscription->getName(),
+                    'isSubscribed' => in_array($subscription->getUuid()->toString(), $subscribedSubscriptionIds)
+                ];
+            }
         }
 
         $user->setSubscriptions($subscriptions);

--- a/api/src/Entity/BulkNotification.php
+++ b/api/src/Entity/BulkNotification.php
@@ -56,24 +56,26 @@ class BulkNotification
     /**
      * @ORM\Column(type="json")
      * @Groups({"bulknotification:collection:write"})
+     * @Groups({"bulknotification:read"})
      */
     private $data = [];
 
     /**
      * @ORM\Column(type="uuid")
-     * @Groups({"bulknotification:collection:write"})
+     * @Groups({"bulknotification:collection:write", "bulknotification:read"})
      */
     private $templateId;
 
     /**
-     * @Groups({"bulknotification:read"})
      * @ORM\OneToMany(targetEntity=UserNotification::class, mappedBy="bulkNotification", orphanRemoval=true)
+     * @Groups({"bulknotification:read"})
      */
     private $userNotifications;
 
     /**
      * @ORM\ManyToOne(targetEntity=Subscription::class, inversedBy="bulkNotifications")
      * @ORM\JoinColumn(nullable=false, referencedColumnName="uuid")
+     * @Groups({"bulknotification:collection:write", "bulknotification:read"})
      */
     private $subscription;
 

--- a/api/src/Entity/BulkNotification.php
+++ b/api/src/Entity/BulkNotification.php
@@ -54,12 +54,6 @@ class BulkNotification
     private $id;
 
     /**
-     * @ORM\Column(type="array")
-     * @Groups({"bulknotification:collection:write", "bulknotification:read"})
-     */
-    private $roles = [];
-
-    /**
      * @ORM\Column(type="json")
      * @Groups({"bulknotification:collection:write"})
      */
@@ -78,10 +72,10 @@ class BulkNotification
     private $userNotifications;
 
     /**
-     * @ORM\Column(type="boolean")
-     * @Groups({"bulknotification:read"})
+     * @ORM\ManyToOne(targetEntity=Subscription::class, inversedBy="bulkNotifications")
+     * @ORM\JoinColumn(nullable=false, referencedColumnName="uuid")
      */
-    private $isMailing = true;
+    private $subscription;
 
     public function __construct()
     {
@@ -91,18 +85,6 @@ class BulkNotification
     public function getId(): UuidInterface
     {
         return $this->id;
-    }
-
-    public function getRoles(): ?array
-    {
-        return $this->roles;
-    }
-
-    public function setRoles(array $roles): self
-    {
-        $this->roles = $roles;
-
-        return $this;
     }
 
     public function getData(): ?array
@@ -159,15 +141,16 @@ class BulkNotification
         return $this;
     }
 
-    public function getIsMailing(): ?bool
+    public function getSubscription(): ?Subscription
     {
-        return $this->isMailing;
+        return $this->subscription;
     }
 
-    public function setIsMailing(bool $isMailing): self
+    public function setSubscription(?Subscription $subscription): self
     {
-        $this->isMailing = $isMailing;
+        $this->subscription = $subscription;
 
         return $this;
     }
+
 }

--- a/api/src/Entity/Subscription.php
+++ b/api/src/Entity/Subscription.php
@@ -48,6 +48,11 @@ class Subscription
      */
     private $userSubscriptions;
 
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    private $optout;
+
     public function __construct()
     {
         $this->userSubscriptions = new ArrayCollection();
@@ -103,6 +108,18 @@ class Subscription
                 $userSubscription->setSubscription(null);
             }
         }
+
+        return $this;
+    }
+
+    public function isOptout(): ?bool
+    {
+        return $this->optout;
+    }
+
+    public function setOptout(bool $optout): self
+    {
+        $this->optout = $optout;
 
         return $this;
     }

--- a/api/src/Entity/Subscription.php
+++ b/api/src/Entity/Subscription.php
@@ -53,9 +53,15 @@ class Subscription
      */
     private $optout;
 
+    /**
+     * @ORM\OneToMany(targetEntity=BulkNotification::class, mappedBy="subscription", orphanRemoval=true)
+     */
+    private $bulkNotifications;
+
     public function __construct()
     {
         $this->userSubscriptions = new ArrayCollection();
+        $this->bulkNotifications = new ArrayCollection();
     }
 
     public function getUuid()
@@ -120,6 +126,36 @@ class Subscription
     public function setOptout(bool $optout): self
     {
         $this->optout = $optout;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, BulkNotification>
+     */
+    public function getBulkNotifications(): Collection
+    {
+        return $this->bulkNotifications;
+    }
+
+    public function addBulkNotification(BulkNotification $bulkNotification): self
+    {
+        if (!$this->bulkNotifications->contains($bulkNotification)) {
+            $this->bulkNotifications[] = $bulkNotification;
+            $bulkNotification->setSubscription($this);
+        }
+
+        return $this;
+    }
+
+    public function removeBulkNotification(BulkNotification $bulkNotification): self
+    {
+        if ($this->bulkNotifications->removeElement($bulkNotification)) {
+            // set the owning side to null (unless already changed)
+            if ($bulkNotification->getSubscription() === $this) {
+                $bulkNotification->setSubscription(null);
+            }
+        }
 
         return $this;
     }

--- a/api/src/Entity/Subscription.php
+++ b/api/src/Entity/Subscription.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use App\Repository\SubscriptionRepository;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+use Doctrine\ORM\Mapping as ORM;
+use ApiPlatform\Core\Annotation\ApiProperty;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * @ORM\Entity(repositoryClass=SubscriptionRepository::class)
+ */
+#[ApiResource]
+class Subscription
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="uuid", unique=true)
+     * @ApiProperty(identifier=true)
+     */
+    private $uuid;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    private $name;
+
+    /**
+     * @ORM\OneToMany(targetEntity=UserSubscription::class, mappedBy="subscription", orphanRemoval=true)
+     */
+    private $userSubscriptions;
+
+    public function __construct()
+    {
+        $this->userSubscriptions = new ArrayCollection();
+    }
+
+    public function getId(): UuidInterface
+    {
+        return $this->uuid;
+    }
+
+    public function getUuid()
+    {
+        return $this->uuid;
+    }
+
+    public function setUuid($uuid): self
+    {
+        $this->uuid = $uuid;
+
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, UserSubscription>
+     */
+    public function getUserSubscriptions(): Collection
+    {
+        return $this->userSubscriptions;
+    }
+
+    public function addUserSubscription(UserSubscription $userSubscription): self
+    {
+        if (!$this->userSubscriptions->contains($userSubscription)) {
+            $this->userSubscriptions[] = $userSubscription;
+            $userSubscription->setSubscription($this);
+        }
+
+        return $this;
+    }
+
+    public function removeUserSubscription(UserSubscription $userSubscription): self
+    {
+        if ($this->userSubscriptions->removeElement($userSubscription)) {
+            // set the owning side to null (unless already changed)
+            if ($userSubscription->getSubscription() === $this) {
+                $userSubscription->setSubscription(null);
+            }
+        }
+
+        return $this;
+    }
+}

--- a/api/src/Entity/Subscription.php
+++ b/api/src/Entity/Subscription.php
@@ -9,11 +9,25 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use ApiPlatform\Core\Annotation\ApiProperty;
 use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
+ * @ApiResource(
+ *     collectionOperations={
+ *          "get"={"security"="is_granted('ROLE_USER')"},
+ *          "post"={"security"="is_granted('ROLE_ADMIN')"},
+ *     },
+ *     itemOperations={
+ *          "get"={"security"="is_granted('ROLE_ADMIN')"},
+ *          "patch"={"security"="is_granted('ROLE_ADMIN')"},
+ *          "delete"={"security"="is_granted('ROLE_ADMIN')"},
+ *     },
+ *     attributes={
+ *          "pagination_enabled"=false,
+ *     }
+ * )
  * @ORM\Entity(repositoryClass=SubscriptionRepository::class)
  */
-#[ApiResource]
 class Subscription
 {
     /**
@@ -25,6 +39,7 @@ class Subscription
 
     /**
      * @ORM\Column(type="string", length=255)
+     * @Groups({"owner:read", "subscription:read"})
      */
     private $name;
 
@@ -36,11 +51,6 @@ class Subscription
     public function __construct()
     {
         $this->userSubscriptions = new ArrayCollection();
-    }
-
-    public function getId(): UuidInterface
-    {
-        return $this->uuid;
     }
 
     public function getUuid()

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -255,6 +255,11 @@ class User implements UserInterface
      */
     private $userSubscriptions;
 
+    /**
+     * @Groups({"user:read", "user:write"})
+     */
+    private $subscriptions = [];
+
     public function __construct()
     {
         $this->tickets = new ArrayCollection();
@@ -716,5 +721,16 @@ class User implements UserInterface
         }
 
         return $this;
+    }
+
+    public function setSubscriptions(array $subscriptions): self
+    {
+        $this->subscriptions = $subscriptions;
+        return $this;
+    }
+
+    public function getSubscriptions(): array
+    {
+        return $this->subscriptions;
     }
 }

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -251,13 +251,6 @@ class User implements UserInterface
     private $userNotifications;
 
     /**
-     * @ORM\GeneratedValue(strategy="CUSTOM")
-     * @ORM\CustomIdGenerator(class=UuidGenerator::class)
-     * @ORM\Column(type="uuid", unique=true)
-     */
-    private $unsubscribeUuid;
-
-    /**
      * @ORM\OneToMany(targetEntity=UserSubscription::class, mappedBy="owner", orphanRemoval=true)
      */
     private $userSubscriptions;
@@ -693,11 +686,6 @@ class User implements UserInterface
         }
 
         return $this;
-    }
-
-    public function getUnsubscribeUuid(): UuidInterface
-    {
-        return $this->unsubscribeUuid;
     }
 
     /**

--- a/api/src/Entity/User.php
+++ b/api/src/Entity/User.php
@@ -257,12 +257,18 @@ class User implements UserInterface
      */
     private $unsubscribeUuid;
 
+    /**
+     * @ORM\OneToMany(targetEntity=UserSubscription::class, mappedBy="owner", orphanRemoval=true)
+     */
+    private $userSubscriptions;
+
     public function __construct()
     {
         $this->tickets = new ArrayCollection();
         $this->orders = new ArrayCollection();
         $this->transactions = new ArrayCollection();
         $this->userNotification = new ArrayCollection();
+        $this->userSubscriptions = new ArrayCollection();
     }
 
     public function getId(): UuidInterface
@@ -692,5 +698,35 @@ class User implements UserInterface
     public function getUnsubscribeUuid(): UuidInterface
     {
         return $this->unsubscribeUuid;
+    }
+
+    /**
+     * @return Collection<int, UserSubscription>
+     */
+    public function getUserSubscriptions(): Collection
+    {
+        return $this->userSubscriptions;
+    }
+
+    public function addUserSubscription(UserSubscription $userSubscription): self
+    {
+        if (!$this->userSubscriptions->contains($userSubscription)) {
+            $this->userSubscriptions[] = $userSubscription;
+            $userSubscription->setOwner($this);
+        }
+
+        return $this;
+    }
+
+    public function removeUserSubscription(UserSubscription $userSubscription): self
+    {
+        if ($this->userSubscriptions->removeElement($userSubscription)) {
+            // set the owning side to null (unless already changed)
+            if ($userSubscription->getOwner() === $this) {
+                $userSubscription->setOwner(null);
+            }
+        }
+
+        return $this;
     }
 }

--- a/api/src/Entity/UserSubscription.php
+++ b/api/src/Entity/UserSubscription.php
@@ -8,6 +8,7 @@ use Doctrine\ORM\Mapping as ORM;
 use ApiPlatform\Core\Annotation\ApiProperty;
 use Ramsey\Uuid\Doctrine\UuidGenerator;
 use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * @ORM\Entity(repositoryClass=UserSubscriptionRepository::class)
@@ -25,20 +26,21 @@ class UserSubscription
     private $uuid;
 
     /**
-     * @ORM\ManyToOne(targetEntity=User::class, inversedBy="userSubscriptions")
+     * @ORM\ManyToOne(targetEntity=User::class, inversedBy="userSubscription")
      * @ORM\JoinColumn(nullable=false, referencedColumnName="uuid")
      */
     private $owner;
 
     /**
-     * @ORM\ManyToOne(targetEntity=Subscription::class, inversedBy="userSubscriptions")
+     * @ORM\ManyToOne(targetEntity=Subscription::class, inversedBy="userSubscription")
      * @ORM\JoinColumn(nullable=false, referencedColumnName="uuid")
+     * @Groups("owner:read")
      */
     private $subscription;
 
-    public function getId(): ?UuidInterface
+    public function getUuid(): ?UuidInterface
     {
-        return $this->id;
+        return $this->uuid;
     }
 
     public function getOwner(): ?User
@@ -53,12 +55,12 @@ class UserSubscription
         return $this;
     }
 
-    public function getSubscription(): ?Subscriptions
+    public function getSubscription(): ?Subscription
     {
         return $this->subscription;
     }
 
-    public function setSubscription(?Subscriptions $subscription): self
+    public function setSubscription(?Subscription $subscription): self
     {
         $this->subscription = $subscription;
 

--- a/api/src/Entity/UserSubscription.php
+++ b/api/src/Entity/UserSubscription.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Entity;
+
+use ApiPlatform\Core\Annotation\ApiResource;
+use App\Repository\UserSubscriptionRepository;
+use Doctrine\ORM\Mapping as ORM;
+use ApiPlatform\Core\Annotation\ApiProperty;
+use Ramsey\Uuid\Doctrine\UuidGenerator;
+use Ramsey\Uuid\UuidInterface;
+
+/**
+ * @ORM\Entity(repositoryClass=UserSubscriptionRepository::class)
+ */
+#[ApiResource]
+class UserSubscription
+{
+    /**
+     * @ORM\Id
+     * @ORM\Column(type="uuid", unique=true)
+     * @ORM\GeneratedValue(strategy="CUSTOM")
+     * @ORM\CustomIdGenerator(class=UuidGenerator::class)
+     * @ApiProperty(identifier=true)
+     */
+    private $uuid;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=User::class, inversedBy="userSubscriptions")
+     * @ORM\JoinColumn(nullable=false, referencedColumnName="uuid")
+     */
+    private $owner;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=Subscription::class, inversedBy="userSubscriptions")
+     * @ORM\JoinColumn(nullable=false, referencedColumnName="uuid")
+     */
+    private $subscription;
+
+    public function getId(): ?UuidInterface
+    {
+        return $this->id;
+    }
+
+    public function getOwner(): ?User
+    {
+        return $this->owner;
+    }
+
+    public function setOwner(?User $owner): self
+    {
+        $this->owner = $owner;
+
+        return $this;
+    }
+
+    public function getSubscription(): ?Subscriptions
+    {
+        return $this->subscription;
+    }
+
+    public function setSubscription(?Subscriptions $subscription): self
+    {
+        $this->subscription = $subscription;
+
+        return $this;
+    }
+}

--- a/api/src/Repository/SubscriptionRepository.php
+++ b/api/src/Repository/SubscriptionRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Subscription;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<Subscription>
+ *
+ * @method Subscription|null find($id, $lockMode = null, $lockVersion = null)
+ * @method Subscription|null findOneBy(array $criteria, array $orderBy = null)
+ * @method Subscription[]    findAll()
+ * @method Subscription[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class SubscriptionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Subscription::class);
+    }
+
+    public function add(Subscription $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->persist($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    public function remove(Subscription $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->remove($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+//    /**
+//     * @return Subscription[] Returns an array of Subscription objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('s')
+//            ->andWhere('s.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('s.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?Subscription
+//    {
+//        return $this->createQueryBuilder('s')
+//            ->andWhere('s.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}

--- a/api/src/Repository/UserSubscriptionRepository.php
+++ b/api/src/Repository/UserSubscriptionRepository.php
@@ -39,6 +39,18 @@ class UserSubscriptionRepository extends ServiceEntityRepository
         }
     }
 
+    public function isUserSubscribed($userUuid, $subscriptionUuid): bool
+    {
+        $qb = $this->createQueryBuilder('us')
+            ->select('count(us.uuid)')
+            ->where('us.owner = :userUuid')
+            ->andWhere('us.subscription = :subscriptionUuid')
+            ->setParameter('userUuid', $userUuid)
+            ->setParameter('subscriptionUuid', $subscriptionUuid);
+
+        return (bool) $qb->getQuery()->getSingleScalarResult();
+    }
+
 //    /**
 //     * @return UserSubscription[] Returns an array of UserSubscription objects
 //     */

--- a/api/src/Repository/UserSubscriptionsRepository.php
+++ b/api/src/Repository/UserSubscriptionsRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\UserSubscription;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<UserSubscription>
+ *
+ * @method UserSubscription|null find($id, $lockMode = null, $lockVersion = null)
+ * @method UserSubscription|null findOneBy(array $criteria, array $orderBy = null)
+ * @method UserSubscription[]    findAll()
+ * @method UserSubscription[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class UserSubscriptionRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, UserSubscription::class);
+    }
+
+    public function add(UserSubscription $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->persist($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    public function remove(UserSubscription $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->remove($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+//    /**
+//     * @return UserSubscription[] Returns an array of UserSubscription objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('u')
+//            ->andWhere('u.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('u.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+//    public function findOneBySomeField($value): ?UserSubscription
+//    {
+//        return $this->createQueryBuilder('u')
+//            ->andWhere('u.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->getQuery()
+//            ->getOneOrNullResult()
+//        ;
+//    }
+}


### PR DESCRIPTION
Significant changes to subscriptions:

- A new entity 'Subscription' for each category of mail that needs to be sent.
- A new entity 'UserSubscription' that links User and Subscription.  Also has a uuid that can be used for a unsubscribe URL (uuid is unique to each User/Subscription).
- Subscription has an 'optout' flag.  If true, email will send out unsubscribe link as part of headers.
- BulkNotification no longer uses groups to send emails to (using subscriptions instead)
- A default subscription is created for the correct user groups in migrations.

Fixes #111, and may fix #112 - pending updates to dependencies.

Will need user approval to add users to subscription, and same for any resigned/lost members.