### PR TITLE
Add legacy user migration preflight command

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -3,3 +3,13 @@
 The API will be here.
 
 Refer to the [Getting Started Guide](https://api-platform.com/docs/distribution) for more information.
+
+## Legacy user migration preflight
+
+Run the read-only, non-PII aggregate report with:
+
+```console
+php bin/console app:user:export-preflight > legacy-user-preflight.json
+```
+
+Run it with read-only database credentials against the intended point-in-time snapshot. The report contains counts plus approved role, rank, and subscription catalogue values; it does not contain user UUIDs, emails, names, phone numbers, service numbers, or password hashes. Review and transfer the report according to the migration procedure even though it contains no direct user records.

--- a/api/src/Command/ExportLegacyUserPreflightCommand.php
+++ b/api/src/Command/ExportLegacyUserPreflightCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Command;
+
+use App\Entity\Subscription;
+use App\Entity\User;
+use App\Service\LegacyUserPreflightBuilder;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ExportLegacyUserPreflightCommand extends Command
+{
+    protected static $defaultName = 'app:user:export-preflight';
+
+    private EntityManagerInterface $entityManager;
+    private LegacyUserPreflightBuilder $builder;
+
+    public function __construct(EntityManagerInterface $entityManager, LegacyUserPreflightBuilder $builder)
+    {
+        parent::__construct();
+        $this->entityManager = $entityManager;
+        $this->builder = $builder;
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Writes a non-PII aggregate preflight report for the legacy user migration.')
+            ->setHelp('The JSON report contains counts and approved catalogue values only. It never emits user identifiers or source field values.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $users = $this->entityManager->createQueryBuilder()
+            ->select('user', 'rank')
+            ->from(User::class, 'user')
+            ->leftJoin('user.rank', 'rank')
+            ->orderBy('user.uuid', 'ASC')
+            ->getQuery()
+            ->toIterable();
+
+        $subscriptions = $this->entityManager->getRepository(Subscription::class)->findBy([], ['uuid' => 'ASC']);
+        $report = $this->builder->build($users, $subscriptions, new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
+        $json = json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        $output->writeln($json);
+
+        return Command::SUCCESS;
+    }
+}

--- a/api/src/Service/LegacyUserPreflightBuilder.php
+++ b/api/src/Service/LegacyUserPreflightBuilder.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace App\Service;
+
+use App\Entity\Subscription;
+use App\Entity\User;
+
+final class LegacyUserPreflightBuilder
+{
+    public const SCHEMA_VERSION = 'sodc-legacy-user-preflight/v1';
+
+    /**
+     * @param iterable<User>         $users
+     * @param iterable<Subscription> $subscriptions
+     */
+    public function build(iterable $users, iterable $subscriptions, \DateTimeImmutable $generatedAt): array
+    {
+        $report = $this->emptyReport($generatedAt);
+        $exactEmails = [];
+        $normalisedEmails = [];
+        $oldUids = [];
+        $roleCombinationCounts = [];
+        $rankCounts = [];
+        $subscriptionMembers = [];
+        $subscriptionPairs = [];
+        $subscriptionsPerUser = [];
+
+        foreach ($subscriptions as $subscription) {
+            $id = (string) $subscription->getUuid();
+            $subscriptionMembers[$id] = [
+                'id' => $id,
+                'name' => $subscription->getName(),
+                'members' => 0,
+            ];
+        }
+
+        foreach ($users as $user) {
+            ++$report['totalUsers'];
+            $this->countEmailQuality($user->getEmail(), $report, $exactEmails, $normalisedEmails);
+            $this->countValue($user->getFirstName(), $report['fieldCompleteness']['firstName']);
+            $this->countValue($user->getLastName(), $report['fieldCompleteness']['lastName']);
+            $this->countValue($user->getServiceNumber(), $report['fieldCompleteness']['serviceNumber']);
+            $this->countValue($user->getMobileNumber(), $report['fieldCompleteness']['mobileNumber']);
+            $this->countValue($user->getPhoneNumber(), $report['fieldCompleteness']['phoneNumber']);
+            $this->countValue($user->getPostNominals(), $report['fieldCompleteness']['postNominals']);
+            $this->countOldUid($user->getOldUid(), $report, $oldUids);
+            $this->countPassword($user->getPassword(), $report);
+            $this->countBoolean($user->getIsShared(), $report['sharing']);
+            $this->countBoolean($user->getIsSubscribed(), $report['legacyIsSubscribed']);
+            $this->countRoles($user, $report, $roleCombinationCounts);
+            $this->countRank($user, $report, $rankCounts);
+
+            $validSubscriptionIds = [];
+            foreach ($user->getUserSubscriptions() as $userSubscription) {
+                $subscription = $userSubscription->getSubscription();
+                if (null === $subscription || null === $subscription->getUuid()) {
+                    ++$report['relationshipQuality']['missingSubscription'];
+                    continue;
+                }
+
+                $subscriptionId = (string) $subscription->getUuid();
+                $pair = (string) $user->getUuid().'|'.$subscriptionId;
+                if (isset($subscriptionPairs[$pair])) {
+                    ++$report['relationshipQuality']['duplicateUserSubscriptionPairs'];
+                    continue;
+                }
+
+                $subscriptionPairs[$pair] = true;
+                $validSubscriptionIds[$subscriptionId] = true;
+                if (!isset($subscriptionMembers[$subscriptionId])) {
+                    ++$report['relationshipQuality']['missingFromCatalogue'];
+                    $subscriptionMembers[$subscriptionId] = [
+                        'id' => $subscriptionId,
+                        'name' => $subscription->getName(),
+                        'members' => 0,
+                    ];
+                }
+                ++$subscriptionMembers[$subscriptionId]['members'];
+                ++$report['subscriptionSummary']['relationshipCount'];
+            }
+
+            $relationshipCount = count($validSubscriptionIds);
+            $subscriptionsPerUser[$relationshipCount] = ($subscriptionsPerUser[$relationshipCount] ?? 0) + 1;
+            $hasSubscriptions = $relationshipCount > 0;
+            ++$report['subscriptionSummary'][$hasSubscriptions ? 'usersWithSubscriptions' : 'usersWithoutSubscriptions'];
+            $correlationKey = $this->booleanKey($user->getIsSubscribed()).'|'.($hasSubscriptions ? 'true' : 'false');
+            $report['subscriptionCorrelation'][$correlationKey] = ($report['subscriptionCorrelation'][$correlationKey] ?? 0) + 1;
+        }
+
+        $report['emailQuality']['duplicateExact'] = $this->duplicateCount($exactEmails);
+        $report['emailQuality']['duplicateNormalized'] = $this->duplicateCount($normalisedEmails);
+        $report['identityQuality']['oldUid']['duplicate'] = $this->duplicateCount($oldUids);
+        $report['subscriptionSummary']['catalogueSize'] = count($subscriptionMembers);
+        $report['roleCombinations'] = $this->formatRoleCombinations($roleCombinationCounts);
+        $report['ranks'] = $this->formatRanks($rankCounts);
+        $report['subscriptions'] = array_values($subscriptionMembers);
+        usort($report['subscriptions'], static fn (array $a, array $b): int => strcmp($a['id'], $b['id']));
+        $report['subscriptionSummary']['subscriptionsPerUser']['distribution'] = $this->formatDistribution($subscriptionsPerUser);
+        $report['subscriptionSummary']['subscriptionsPerUser']['minimum'] = empty($subscriptionsPerUser) ? 0 : min(array_keys($subscriptionsPerUser));
+        $report['subscriptionSummary']['subscriptionsPerUser']['maximum'] = empty($subscriptionsPerUser) ? 0 : max(array_keys($subscriptionsPerUser));
+        $report['subscriptionCorrelation'] = $this->formatCorrelation($report['subscriptionCorrelation']);
+
+        return $report;
+    }
+
+    private function emptyReport(\DateTimeImmutable $generatedAt): array
+    {
+        $fieldCount = static fn (): array => ['null' => 0, 'blank' => 0, 'present' => 0];
+
+        return [
+            'schemaVersion' => self::SCHEMA_VERSION,
+            'generatedAt' => $generatedAt->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d\TH:i:s\Z'),
+            'totalUsers' => 0,
+            'emailQuality' => ['missing' => 0, 'blank' => 0, 'invalid' => 0, 'leadingOrTrailingWhitespace' => 0, 'duplicateExact' => 0, 'duplicateNormalized' => 0],
+            'identityQuality' => ['oldUid' => ['missing' => 0, 'present' => 0, 'duplicate' => 0]],
+            'fieldCompleteness' => [
+                'firstName' => $fieldCount(), 'lastName' => $fieldCount(), 'serviceNumber' => $fieldCount(),
+                'mobileNumber' => $fieldCount(), 'phoneNumber' => $fieldCount(), 'postNominals' => $fieldCount(),
+            ],
+            'passwords' => ['present' => 0, 'blank' => 0, 'supported' => 0, 'unsupportedOrMalformed' => 0, 'algorithms' => ['bcrypt' => 0, 'argon2i' => 0, 'argon2id' => 0]],
+            'roles' => ['empty' => 0, 'counts' => []],
+            'roleCombinations' => [],
+            'membershipConsistency' => ['memberFlagAndRole' => 0, 'memberFlagWithoutRole' => 0, 'memberRoleWithoutFlag' => 0, 'neither' => 0, 'nullFlag' => 0],
+            'ranks' => [],
+            'rankQuality' => ['missing' => 0],
+            'sharing' => ['true' => 0, 'false' => 0, 'null' => 0],
+            'legacyIsSubscribed' => ['true' => 0, 'false' => 0, 'null' => 0],
+            'subscriptionSummary' => ['catalogueSize' => 0, 'usersWithSubscriptions' => 0, 'usersWithoutSubscriptions' => 0, 'relationshipCount' => 0, 'subscriptionsPerUser' => ['minimum' => 0, 'maximum' => 0, 'distribution' => []]],
+            'subscriptionCorrelation' => [],
+            'relationshipQuality' => ['missingSubscription' => 0, 'missingFromCatalogue' => 0, 'duplicateUserSubscriptionPairs' => 0],
+            'subscriptions' => [],
+        ];
+    }
+
+    private function countEmailQuality(?string $email, array &$report, array &$exact, array &$normalised): void
+    {
+        if (null === $email) {
+            ++$report['emailQuality']['missing'];
+            return;
+        }
+        if ('' === $email) {
+            ++$report['emailQuality']['blank'];
+            return;
+        }
+        if ($email !== trim($email)) {
+            ++$report['emailQuality']['leadingOrTrailingWhitespace'];
+        }
+        if (false === filter_var($email, FILTER_VALIDATE_EMAIL)) {
+            ++$report['emailQuality']['invalid'];
+        }
+        $exact[$email] = ($exact[$email] ?? 0) + 1;
+        $key = strtolower(trim($email));
+        $normalised[$key] = ($normalised[$key] ?? 0) + 1;
+    }
+
+    private function countValue(?string $value, array &$counts): void
+    {
+        ++$counts[null === $value ? 'null' : ('' === $value ? 'blank' : 'present')];
+    }
+
+    private function countOldUid(?int $oldUid, array &$report, array &$oldUids): void
+    {
+        if (null === $oldUid) {
+            ++$report['identityQuality']['oldUid']['missing'];
+            return;
+        }
+        ++$report['identityQuality']['oldUid']['present'];
+        $oldUids[$oldUid] = ($oldUids[$oldUid] ?? 0) + 1;
+    }
+
+    private function countPassword(string $password, array &$report): void
+    {
+        if ('' === $password) {
+            ++$report['passwords']['blank'];
+            return;
+        }
+        ++$report['passwords']['present'];
+        $info = password_get_info($password);
+        $algorithm = $info['algoName'] ?? 'unknown';
+        if (isset($report['passwords']['algorithms'][$algorithm])) {
+            ++$report['passwords']['algorithms'][$algorithm];
+            ++$report['passwords']['supported'];
+        } else {
+            ++$report['passwords']['unsupportedOrMalformed'];
+        }
+    }
+
+    private function countBoolean(?bool $value, array &$counts): void
+    {
+        ++$counts[$this->booleanKey($value)];
+    }
+
+    private function booleanKey(?bool $value): string
+    {
+        return null === $value ? 'null' : ($value ? 'true' : 'false');
+    }
+
+    private function countRoles(User $user, array &$report, array &$combinations): void
+    {
+        $roles = $user->getRoles();
+        $unique = array_values(array_unique($roles));
+        sort($unique, SORT_STRING);
+        if (empty($unique)) {
+            ++$report['roles']['empty'];
+        }
+        foreach ($unique as $role) {
+            $report['roles']['counts'][$role] = ($report['roles']['counts'][$role] ?? 0) + 1;
+        }
+        ksort($report['roles']['counts'], SORT_STRING);
+        $memberRole = in_array('ROLE_MEMBER', $unique, true);
+        $memberFlag = $user->getIsMember();
+        if (null === $memberFlag) {
+            ++$report['membershipConsistency']['nullFlag'];
+        } elseif ($memberFlag && $memberRole) {
+            ++$report['membershipConsistency']['memberFlagAndRole'];
+        } elseif ($memberFlag) {
+            ++$report['membershipConsistency']['memberFlagWithoutRole'];
+        } elseif ($memberRole) {
+            ++$report['membershipConsistency']['memberRoleWithoutFlag'];
+        } else {
+            ++$report['membershipConsistency']['neither'];
+        }
+        $key = json_encode([$unique, $memberFlag], JSON_THROW_ON_ERROR);
+        $combinations[$key] = ($combinations[$key] ?? 0) + 1;
+    }
+
+    private function countRank(User $user, array &$report, array &$ranks): void
+    {
+        $rank = $user->getRank();
+        if (null === $rank) {
+            ++$report['rankQuality']['missing'];
+            return;
+        }
+        $key = $rank->getId().'|'.$rank->getRank();
+        $ranks[$key] = ['id' => $rank->getId(), 'value' => $rank->getRank(), 'count' => ($ranks[$key]['count'] ?? 0) + 1];
+    }
+
+    private function duplicateCount(array $counts): int
+    {
+        return array_sum(array_map(static fn (int $count): int => max(0, $count - 1), $counts));
+    }
+
+    private function formatRoleCombinations(array $counts): array
+    {
+        ksort($counts, SORT_STRING);
+        $result = [];
+        foreach ($counts as $key => $count) {
+            [$roles, $isMember] = json_decode($key, true, 512, JSON_THROW_ON_ERROR);
+            $result[] = ['roles' => $roles, 'isMember' => $isMember, 'count' => $count];
+        }
+        return $result;
+    }
+
+    private function formatRanks(array $ranks): array
+    {
+        $result = array_values($ranks);
+        usort($result, static fn (array $a, array $b): int => [$a['id'], $a['value']] <=> [$b['id'], $b['value']]);
+        return $result;
+    }
+
+    private function formatDistribution(array $counts): array
+    {
+        ksort($counts, SORT_NUMERIC);
+        $result = [];
+        foreach ($counts as $count => $users) {
+            $result[] = ['count' => (int) $count, 'users' => $users];
+        }
+        return $result;
+    }
+
+    private function formatCorrelation(array $counts): array
+    {
+        $result = [];
+        foreach (['true', 'false', 'null'] as $flag) {
+            foreach (['true', 'false'] as $hasRelationships) {
+                $result[] = [
+                    'isSubscribed' => 'null' === $flag ? null : 'true' === $flag,
+                    'hasSubscriptionRelationships' => 'true' === $hasRelationships,
+                    'users' => $counts[$flag.'|'.$hasRelationships] ?? 0,
+                ];
+            }
+        }
+        return $result;
+    }
+}

--- a/api/tests/Unit/Service/LegacyUserPreflightBuilderTest.php
+++ b/api/tests/Unit/Service/LegacyUserPreflightBuilderTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Tests\Unit\Service;
+
+use App\Entity\Rank;
+use App\Entity\Subscription;
+use App\Entity\User;
+use App\Entity\UserSubscription;
+use App\Service\LegacyUserPreflightBuilder;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid;
+
+final class LegacyUserPreflightBuilderTest extends TestCase
+{
+    public function testBuildsDeterministicNonPiiAggregateReport(): void
+    {
+        $news = $this->subscription('00000000-0000-0000-0000-000000000002', 'News');
+        $events = $this->subscription('00000000-0000-0000-0000-000000000001', 'Events');
+
+        $member = $this->user('00000000-0000-0000-0000-000000000010', 'Member@Example.org', true, true);
+        $member->setOldUid(7);
+        $member->setRoles(['ROLE_USER', 'ROLE_MEMBER']);
+        $member->setFirstName('Example');
+        $member->setLastName('Member');
+        $member->setServiceNumber('123');
+        $member->setMobileNumber('07123456789');
+        $member->setPassword(password_hash('secret', PASSWORD_BCRYPT));
+        $member->setRank($this->rank(1, 'Sqn Ldr'));
+        $member->addUserSubscription($this->relationship($events));
+        $member->addUserSubscription($this->relationship($news));
+        $member->addUserSubscription($this->relationship($news));
+
+        $nonMember = $this->user('00000000-0000-0000-0000-000000000011', ' member@example.org ', false, false);
+        $nonMember->setOldUid(7);
+        $nonMember->setRoles([]);
+        $nonMember->setFirstName('');
+        $nonMember->setLastName(null);
+        $nonMember->setPassword('not-a-supported-hash');
+
+        $report = (new LegacyUserPreflightBuilder())->build(
+            [$member, $nonMember],
+            [$news, $events],
+            new \DateTimeImmutable('2026-07-19T14:00:00+00:00')
+        );
+
+        self::assertSame(LegacyUserPreflightBuilder::SCHEMA_VERSION, $report['schemaVersion']);
+        self::assertSame('2026-07-19T14:00:00Z', $report['generatedAt']);
+        self::assertSame(2, $report['totalUsers']);
+        self::assertSame(1, $report['emailQuality']['duplicateNormalized']);
+        self::assertSame(1, $report['emailQuality']['leadingOrTrailingWhitespace']);
+        self::assertSame(1, $report['identityQuality']['oldUid']['duplicate']);
+        self::assertSame(1, $report['passwords']['supported']);
+        self::assertSame(1, $report['passwords']['unsupportedOrMalformed']);
+        self::assertSame(1, $report['membershipConsistency']['memberFlagAndRole']);
+        self::assertSame(1, $report['membershipConsistency']['neither']);
+        self::assertSame(1, $report['relationshipQuality']['duplicateUserSubscriptionPairs']);
+        self::assertSame(2, $report['subscriptionSummary']['relationshipCount']);
+        self::assertSame([
+            ['count' => 0, 'users' => 1],
+            ['count' => 2, 'users' => 1],
+        ], $report['subscriptionSummary']['subscriptionsPerUser']['distribution']);
+        self::assertSame('00000000-0000-0000-0000-000000000001', $report['subscriptions'][0]['id']);
+        self::assertSame(1, $report['subscriptions'][0]['members']);
+        self::assertSame(1, $report['subscriptionCorrelation'][0]['users']);
+        self::assertSame(1, $report['subscriptionCorrelation'][3]['users']);
+
+        $encoded = json_encode($report, JSON_THROW_ON_ERROR);
+        self::assertStringNotContainsString('Member@Example.org', $encoded);
+        self::assertStringNotContainsString('07123456789', $encoded);
+        self::assertStringNotContainsString('$2y$', $encoded);
+    }
+
+    private function user(string $uuid, string $email, bool $isMember, bool $isSubscribed): User
+    {
+        $user = new User();
+        $user->setUuid(Uuid::fromString($uuid));
+        $this->setProperty($user, 'email', $email);
+        $user->setIsMember($isMember);
+        $user->setIsSubscribed($isSubscribed);
+        $user->setIsShared(true);
+
+        return $user;
+    }
+
+    private function subscription(string $uuid, string $name): Subscription
+    {
+        $subscription = new Subscription();
+        $subscription->setUuid(Uuid::fromString($uuid));
+        $subscription->setName($name);
+
+        return $subscription;
+    }
+
+    private function relationship(Subscription $subscription): UserSubscription
+    {
+        return (new UserSubscription())->setSubscription($subscription);
+    }
+
+    private function rank(int $id, string $value): Rank
+    {
+        $rank = (new Rank())->setRank($value);
+        $this->setProperty($rank, 'id', $id);
+
+        return $rank;
+    }
+
+    private function setProperty(object $object, string $property, $value): void
+    {
+        $reflection = new \ReflectionProperty($object, $property);
+        $reflection->setAccessible(true);
+        $reflection->setValue($object, $value);
+    }
+}


### PR DESCRIPTION
## Summary
- add a read-only Symfony CLI command that emits the v1 non-PII legacy-user preflight report
- report identity, field, password, role, rank, membership, and subscription aggregate quality
- correlate the legacy isSubscribed flag with authoritative user-subscription relationships
- document safe CLI usage and add focused unit coverage

## Test plan
- docker compose run --rm --no-deps --entrypoint php php bin/phpunit tests/Unit/Service/LegacyUserPreflightBuilderTest.php
- PHP syntax checks for the command, builder, and test
- confirmed app:user:export-preflight is registered

Closes #141