### PR TITLE
Add migration eligibility and membership status rules

### DIFF
--- a/api/src/Service/LegacyUserPreflightBuilder.php
+++ b/api/src/Service/LegacyUserPreflightBuilder.php
@@ -36,6 +36,14 @@ final class LegacyUserPreflightBuilder
 
         foreach ($users as $user) {
             ++$report['totalUsers'];
+            $roles = $user->getRoles();
+            if (in_array('ROLE_DELETED', $roles, true)) {
+                ++$report['eligibility']['excludedRoleDeleted'];
+                continue;
+            }
+
+            ++$report['eligibility']['includedUsers'];
+            ++$report['membershipStatuses'][$this->membershipStatus($roles, $user->getIsMember())];
             $this->countEmailQuality($user->getEmail(), $report, $exactEmails, $normalisedEmails);
             $this->countValue($user->getFirstName(), $report['fieldCompleteness']['firstName']);
             $this->countValue($user->getLastName(), $report['fieldCompleteness']['lastName']);
@@ -82,7 +90,7 @@ final class LegacyUserPreflightBuilder
             $relationshipCount = count($validSubscriptionIds);
             $subscriptionsPerUser[$relationshipCount] = ($subscriptionsPerUser[$relationshipCount] ?? 0) + 1;
             $hasSubscriptions = $relationshipCount > 0;
-            ++$report['subscriptionSummary'][$hasSubscriptions ? 'usersWithSubscriptions' : 'usersWithoutSubscriptions'];
+            ++$report['hasSubscriptions'][$hasSubscriptions ? 'true' : 'false'];
             $correlationKey = $this->booleanKey($user->getIsSubscribed()).'|'.($hasSubscriptions ? 'true' : 'false');
             $report['subscriptionCorrelation'][$correlationKey] = ($report['subscriptionCorrelation'][$correlationKey] ?? 0) + 1;
         }
@@ -111,6 +119,8 @@ final class LegacyUserPreflightBuilder
             'schemaVersion' => self::SCHEMA_VERSION,
             'generatedAt' => $generatedAt->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d\TH:i:s\Z'),
             'totalUsers' => 0,
+            'eligibility' => ['excludedRoleDeleted' => 0, 'includedUsers' => 0],
+            'membershipStatuses' => ['active' => 0, 'pending' => 0, 'resigned' => 0, 'deceased' => 0, 'lost' => 0],
             'emailQuality' => ['missing' => 0, 'blank' => 0, 'invalid' => 0, 'leadingOrTrailingWhitespace' => 0, 'duplicateExact' => 0, 'duplicateNormalized' => 0],
             'identityQuality' => ['oldUid' => ['missing' => 0, 'present' => 0, 'duplicate' => 0]],
             'fieldCompleteness' => [
@@ -125,7 +135,8 @@ final class LegacyUserPreflightBuilder
             'rankQuality' => ['missing' => 0],
             'sharing' => ['true' => 0, 'false' => 0, 'null' => 0],
             'legacyIsSubscribed' => ['true' => 0, 'false' => 0, 'null' => 0],
-            'subscriptionSummary' => ['catalogueSize' => 0, 'usersWithSubscriptions' => 0, 'usersWithoutSubscriptions' => 0, 'relationshipCount' => 0, 'subscriptionsPerUser' => ['minimum' => 0, 'maximum' => 0, 'distribution' => []]],
+            'hasSubscriptions' => ['true' => 0, 'false' => 0],
+            'subscriptionSummary' => ['catalogueSize' => 0, 'relationshipCount' => 0, 'subscriptionsPerUser' => ['minimum' => 0, 'maximum' => 0, 'distribution' => []]],
             'subscriptionCorrelation' => [],
             'relationshipQuality' => ['missingSubscription' => 0, 'missingFromCatalogue' => 0, 'duplicateUserSubscriptionPairs' => 0],
             'subscriptions' => [],
@@ -193,6 +204,21 @@ final class LegacyUserPreflightBuilder
     private function booleanKey(?bool $value): string
     {
         return null === $value ? 'null' : ($value ? 'true' : 'false');
+    }
+
+    private function membershipStatus(array $roles, ?bool $isMember): string
+    {
+        foreach ([
+            'ROLE_RESIGNED' => 'resigned',
+            'ROLE_DECEASED' => 'deceased',
+            'ROLE_LOST' => 'lost',
+        ] as $role => $status) {
+            if (in_array($role, $roles, true)) {
+                return $status;
+            }
+        }
+
+        return true === $isMember ? 'active' : 'pending';
     }
 
     private function countRoles(User $user, array &$report, array &$combinations): void

--- a/api/tests/Unit/Service/LegacyUserPreflightBuilderTest.php
+++ b/api/tests/Unit/Service/LegacyUserPreflightBuilderTest.php
@@ -46,6 +46,9 @@ final class LegacyUserPreflightBuilderTest extends TestCase
         self::assertSame(LegacyUserPreflightBuilder::SCHEMA_VERSION, $report['schemaVersion']);
         self::assertSame('2026-07-19T14:00:00Z', $report['generatedAt']);
         self::assertSame(2, $report['totalUsers']);
+        self::assertSame(['excludedRoleDeleted' => 0, 'includedUsers' => 2], $report['eligibility']);
+        self::assertSame(['active' => 1, 'pending' => 1, 'resigned' => 0, 'deceased' => 0, 'lost' => 0], $report['membershipStatuses']);
+        self::assertSame(['true' => 1, 'false' => 1], $report['hasSubscriptions']);
         self::assertSame(1, $report['emailQuality']['duplicateNormalized']);
         self::assertSame(1, $report['emailQuality']['leadingOrTrailingWhitespace']);
         self::assertSame(1, $report['identityQuality']['oldUid']['duplicate']);
@@ -68,6 +71,43 @@ final class LegacyUserPreflightBuilderTest extends TestCase
         self::assertStringNotContainsString('Member@Example.org', $encoded);
         self::assertStringNotContainsString('07123456789', $encoded);
         self::assertStringNotContainsString('$2y$', $encoded);
+    }
+
+    public function testExcludesDeletedUsersAndAppliesMembershipStatusPriority(): void
+    {
+        $deleted = $this->user('00000000-0000-0000-0000-000000000020', 'deleted@example.org', true, true);
+        $deleted->setRoles(['ROLE_DELETED', 'ROLE_RESIGNED']);
+
+        $resigned = $this->user('00000000-0000-0000-0000-000000000021', 'resigned@example.org', true, true);
+        $resigned->setRoles(['ROLE_LOST', 'ROLE_DECEASED', 'ROLE_RESIGNED']);
+
+        $deceased = $this->user('00000000-0000-0000-0000-000000000022', 'deceased@example.org', true, true);
+        $deceased->setRoles(['ROLE_LOST', 'ROLE_DECEASED']);
+
+        $lost = $this->user('00000000-0000-0000-0000-000000000023', 'lost@example.org', true, true);
+        $lost->setRoles(['ROLE_LOST']);
+
+        $pending = $this->user('00000000-0000-0000-0000-000000000024', 'pending@example.org', false, true);
+        $active = $this->user('00000000-0000-0000-0000-000000000025', 'active@example.org', true, true);
+
+        $report = (new LegacyUserPreflightBuilder())->build(
+            [$deleted, $resigned, $deceased, $lost, $pending, $active],
+            [],
+            new \DateTimeImmutable('2026-07-19T14:00:00+00:00')
+        );
+
+        self::assertSame(6, $report['totalUsers']);
+        self::assertSame(['excludedRoleDeleted' => 1, 'includedUsers' => 5], $report['eligibility']);
+        self::assertSame([
+            'active' => 1,
+            'pending' => 1,
+            'resigned' => 1,
+            'deceased' => 1,
+            'lost' => 1,
+        ], $report['membershipStatuses']);
+        self::assertSame(['true' => 0, 'false' => 5], $report['hasSubscriptions']);
+        self::assertSame(0, $report['emailQuality']['invalid']);
+        self::assertSame(0, $report['emailQuality']['missing']);
     }
 
     private function user(string $uuid, string $email, bool $isMember, bool $isSubscribed): User


### PR DESCRIPTION
## Summary

- exclude users with the exact `ROLE_DELETED` role from migration aggregates
- derive one membership status per included user using `ROLE_RESIGNED`, `ROLE_DECEASED`, and `ROLE_LOST` priority, then active or pending from `isMember`
- report the export-facing subscription decision as aggregate `hasSubscriptions` boolean counts
- add coverage for role overlap, exclusion, pending membership, and subscription presence

## Why

This makes the preflight reflect the agreed migration rules before the detailed export is implemented.

## Validation

- `LegacyUserPreflightBuilderTest`: 2 tests, 29 assertions
- `git diff --check`

Follow-up to #142. Part of #141.
