### PR TITLE
Add preflight attribute cohorts by old UID

### DIFF
--- a/api/src/Service/LegacyUserPreflightBuilder.php
+++ b/api/src/Service/LegacyUserPreflightBuilder.php
@@ -43,7 +43,10 @@ final class LegacyUserPreflightBuilder
             }
 
             ++$report['eligibility']['includedUsers'];
-            ++$report['membershipStatuses'][$this->membershipStatus($roles, $user->getIsMember())];
+            $membershipStatus = $this->membershipStatus($roles, $user->getIsMember());
+            ++$report['membershipStatuses'][$membershipStatus];
+            $oldUidCohort = null === $user->getOldUid() ? 'missing' : 'set';
+            $this->countOldUidCohortAttributes($user, $roles, $membershipStatus, $report['attributesByOldUid'][$oldUidCohort]);
             $this->countEmailQuality($user->getEmail(), $report, $exactEmails, $normalisedEmails);
             $this->countValue($user->getFirstName(), $report['fieldCompleteness']['firstName']);
             $this->countValue($user->getLastName(), $report['fieldCompleteness']['lastName']);
@@ -91,6 +94,7 @@ final class LegacyUserPreflightBuilder
             $subscriptionsPerUser[$relationshipCount] = ($subscriptionsPerUser[$relationshipCount] ?? 0) + 1;
             $hasSubscriptions = $relationshipCount > 0;
             ++$report['hasSubscriptions'][$hasSubscriptions ? 'true' : 'false'];
+            ++$report['attributesByOldUid'][$oldUidCohort]['hasSubscriptions'][$hasSubscriptions ? 'true' : 'false'];
             $correlationKey = $this->booleanKey($user->getIsSubscribed()).'|'.($hasSubscriptions ? 'true' : 'false');
             $report['subscriptionCorrelation'][$correlationKey] = ($report['subscriptionCorrelation'][$correlationKey] ?? 0) + 1;
         }
@@ -123,6 +127,10 @@ final class LegacyUserPreflightBuilder
             'membershipStatuses' => ['active' => 0, 'pending' => 0, 'resigned' => 0, 'deceased' => 0, 'lost' => 0],
             'emailQuality' => ['missing' => 0, 'blank' => 0, 'invalid' => 0, 'leadingOrTrailingWhitespace' => 0, 'duplicateExact' => 0, 'duplicateNormalized' => 0],
             'identityQuality' => ['oldUid' => ['missing' => 0, 'present' => 0, 'duplicate' => 0]],
+            'attributesByOldUid' => [
+                'set' => $this->emptyOldUidCohort(),
+                'missing' => $this->emptyOldUidCohort(),
+            ],
             'fieldCompleteness' => [
                 'firstName' => $fieldCount(), 'lastName' => $fieldCount(), 'serviceNumber' => $fieldCount(),
                 'mobileNumber' => $fieldCount(), 'phoneNumber' => $fieldCount(), 'postNominals' => $fieldCount(),
@@ -167,6 +175,47 @@ final class LegacyUserPreflightBuilder
     private function countValue(?string $value, array &$counts): void
     {
         ++$counts[null === $value ? 'null' : ('' === $value ? 'blank' : 'present')];
+    }
+
+    private function emptyOldUidCohort(): array
+    {
+        $valueCounts = static fn (): array => ['null' => 0, 'blank' => 0, 'present' => 0];
+
+        return [
+            'users' => 0,
+            'attributes' => [
+                'email' => $valueCounts(),
+                'firstName' => $valueCounts(),
+                'lastName' => $valueCounts(),
+                'mobileNumber' => $valueCounts(),
+                'phoneNumber' => $valueCounts(),
+                'postNominals' => $valueCounts(),
+                'serviceNumber' => $valueCounts(),
+                'rank' => ['missing' => 0, 'present' => 0],
+                'roles' => ['empty' => 0, 'present' => 0],
+                'passwordHash' => ['blank' => 0, 'present' => 0],
+                'isShared' => ['true' => 0, 'false' => 0, 'null' => 0],
+            ],
+            'membershipStatuses' => ['active' => 0, 'pending' => 0, 'resigned' => 0, 'deceased' => 0, 'lost' => 0],
+            'hasSubscriptions' => ['true' => 0, 'false' => 0],
+        ];
+    }
+
+    private function countOldUidCohortAttributes(User $user, array $roles, string $membershipStatus, array &$cohort): void
+    {
+        ++$cohort['users'];
+        $this->countValue($user->getEmail(), $cohort['attributes']['email']);
+        $this->countValue($user->getFirstName(), $cohort['attributes']['firstName']);
+        $this->countValue($user->getLastName(), $cohort['attributes']['lastName']);
+        $this->countValue($user->getMobileNumber(), $cohort['attributes']['mobileNumber']);
+        $this->countValue($user->getPhoneNumber(), $cohort['attributes']['phoneNumber']);
+        $this->countValue($user->getPostNominals(), $cohort['attributes']['postNominals']);
+        $this->countValue($user->getServiceNumber(), $cohort['attributes']['serviceNumber']);
+        ++$cohort['attributes']['rank'][null === $user->getRank() ? 'missing' : 'present'];
+        ++$cohort['attributes']['roles'][empty($roles) ? 'empty' : 'present'];
+        ++$cohort['attributes']['passwordHash']['' === $user->getPassword() ? 'blank' : 'present'];
+        $this->countBoolean($user->getIsShared(), $cohort['attributes']['isShared']);
+        ++$cohort['membershipStatuses'][$membershipStatus];
     }
 
     private function countOldUid(?int $oldUid, array &$report, array &$oldUids): void

--- a/api/tests/Unit/Service/LegacyUserPreflightBuilderTest.php
+++ b/api/tests/Unit/Service/LegacyUserPreflightBuilderTest.php
@@ -49,6 +49,14 @@ final class LegacyUserPreflightBuilderTest extends TestCase
         self::assertSame(['excludedRoleDeleted' => 0, 'includedUsers' => 2], $report['eligibility']);
         self::assertSame(['active' => 1, 'pending' => 1, 'resigned' => 0, 'deceased' => 0, 'lost' => 0], $report['membershipStatuses']);
         self::assertSame(['true' => 1, 'false' => 1], $report['hasSubscriptions']);
+        self::assertSame(2, $report['attributesByOldUid']['set']['users']);
+        self::assertSame(0, $report['attributesByOldUid']['missing']['users']);
+        self::assertSame(['null' => 0, 'blank' => 0, 'present' => 2], $report['attributesByOldUid']['set']['attributes']['email']);
+        self::assertSame(['null' => 0, 'blank' => 1, 'present' => 1], $report['attributesByOldUid']['set']['attributes']['firstName']);
+        self::assertSame(['missing' => 1, 'present' => 1], $report['attributesByOldUid']['set']['attributes']['rank']);
+        self::assertSame(['empty' => 1, 'present' => 1], $report['attributesByOldUid']['set']['attributes']['roles']);
+        self::assertSame(['active' => 1, 'pending' => 1, 'resigned' => 0, 'deceased' => 0, 'lost' => 0], $report['attributesByOldUid']['set']['membershipStatuses']);
+        self::assertSame(['true' => 1, 'false' => 1], $report['attributesByOldUid']['set']['hasSubscriptions']);
         self::assertSame(1, $report['emailQuality']['duplicateNormalized']);
         self::assertSame(1, $report['emailQuality']['leadingOrTrailingWhitespace']);
         self::assertSame(1, $report['identityQuality']['oldUid']['duplicate']);
@@ -106,6 +114,17 @@ final class LegacyUserPreflightBuilderTest extends TestCase
             'lost' => 1,
         ], $report['membershipStatuses']);
         self::assertSame(['true' => 0, 'false' => 5], $report['hasSubscriptions']);
+        self::assertSame(0, $report['attributesByOldUid']['set']['users']);
+        self::assertSame(5, $report['attributesByOldUid']['missing']['users']);
+        self::assertSame(['null' => 0, 'blank' => 0, 'present' => 5], $report['attributesByOldUid']['missing']['attributes']['email']);
+        self::assertSame([
+            'active' => 1,
+            'pending' => 1,
+            'resigned' => 1,
+            'deceased' => 1,
+            'lost' => 1,
+        ], $report['attributesByOldUid']['missing']['membershipStatuses']);
+        self::assertSame(['true' => 0, 'false' => 5], $report['attributesByOldUid']['missing']['hasSubscriptions']);
         self::assertSame(0, $report['emailQuality']['invalid']);
         self::assertSame(0, $report['emailQuality']['missing']);
     }


### PR DESCRIPTION
## Summary

- split included users into `oldUid` set and missing cohorts
- report export-relevant attribute completeness for each cohort
- include membership-status, sharing, and derived `hasSubscriptions` distributions
- keep legacy `isSubscribed` outside these cohorts as agreed
- exclude `ROLE_DELETED` users before cohorting

## Why

This lets the migration preflight show whether records with and without `oldUid` have materially different data completeness without exposing user-level data.

## Validation

- `LegacyUserPreflightBuilderTest`: 2 tests, 42 assertions
- PHP syntax validation
- `git diff --check`

Follow-up to #143. Part of #141.
