### PR TITLE
Refine membership and mobile export preflight

### DIFF
--- a/api/src/Service/LegacyUserPreflightBuilder.php
+++ b/api/src/Service/LegacyUserPreflightBuilder.php
@@ -51,8 +51,7 @@ final class LegacyUserPreflightBuilder
             $this->countValue($user->getFirstName(), $report['fieldCompleteness']['firstName']);
             $this->countValue($user->getLastName(), $report['fieldCompleteness']['lastName']);
             $this->countValue($user->getServiceNumber(), $report['fieldCompleteness']['serviceNumber']);
-            $this->countValue($user->getMobileNumber(), $report['fieldCompleteness']['mobileNumber']);
-            $this->countValue($user->getPhoneNumber(), $report['fieldCompleteness']['phoneNumber']);
+            $this->countExportMobileNumber($user, $report['fieldCompleteness']['mobileNumber'], $report['mobileNumberSource']);
             $this->countValue($user->getPostNominals(), $report['fieldCompleteness']['postNominals']);
             $this->countOldUid($user->getOldUid(), $report, $oldUids);
             $this->countPassword($user->getPassword(), $report);
@@ -124,7 +123,7 @@ final class LegacyUserPreflightBuilder
             'generatedAt' => $generatedAt->setTimezone(new \DateTimeZone('UTC'))->format('Y-m-d\TH:i:s\Z'),
             'totalUsers' => 0,
             'eligibility' => ['excludedRoleDeleted' => 0, 'includedUsers' => 0],
-            'membershipStatuses' => ['active' => 0, 'pending' => 0, 'resigned' => 0, 'deceased' => 0, 'lost' => 0],
+            'membershipStatuses' => ['active' => 0, 'pending' => 0, 'resigned' => 0, 'deceased' => 0, 'lost' => 0, 'regular' => 0, 'retired' => 0],
             'emailQuality' => ['missing' => 0, 'blank' => 0, 'invalid' => 0, 'leadingOrTrailingWhitespace' => 0, 'duplicateExact' => 0, 'duplicateNormalized' => 0],
             'identityQuality' => ['oldUid' => ['missing' => 0, 'present' => 0, 'duplicate' => 0]],
             'attributesByOldUid' => [
@@ -133,8 +132,9 @@ final class LegacyUserPreflightBuilder
             ],
             'fieldCompleteness' => [
                 'firstName' => $fieldCount(), 'lastName' => $fieldCount(), 'serviceNumber' => $fieldCount(),
-                'mobileNumber' => $fieldCount(), 'phoneNumber' => $fieldCount(), 'postNominals' => $fieldCount(),
+                'mobileNumber' => $fieldCount(), 'postNominals' => $fieldCount(),
             ],
+            'mobileNumberSource' => ['mobileNumber' => 0, 'phoneNumberFallback' => 0, 'none' => 0],
             'passwords' => ['present' => 0, 'blank' => 0, 'supported' => 0, 'unsupportedOrMalformed' => 0, 'algorithms' => ['bcrypt' => 0, 'argon2i' => 0, 'argon2id' => 0]],
             'roles' => ['empty' => 0, 'counts' => []],
             'roleCombinations' => [],
@@ -188,7 +188,7 @@ final class LegacyUserPreflightBuilder
                 'firstName' => $valueCounts(),
                 'lastName' => $valueCounts(),
                 'mobileNumber' => $valueCounts(),
-                'phoneNumber' => $valueCounts(),
+                'mobileNumberSource' => ['mobileNumber' => 0, 'phoneNumberFallback' => 0, 'none' => 0],
                 'postNominals' => $valueCounts(),
                 'serviceNumber' => $valueCounts(),
                 'rank' => ['missing' => 0, 'present' => 0],
@@ -196,7 +196,7 @@ final class LegacyUserPreflightBuilder
                 'passwordHash' => ['blank' => 0, 'present' => 0],
                 'isShared' => ['true' => 0, 'false' => 0, 'null' => 0],
             ],
-            'membershipStatuses' => ['active' => 0, 'pending' => 0, 'resigned' => 0, 'deceased' => 0, 'lost' => 0],
+            'membershipStatuses' => ['active' => 0, 'pending' => 0, 'resigned' => 0, 'deceased' => 0, 'lost' => 0, 'regular' => 0, 'retired' => 0],
             'hasSubscriptions' => ['true' => 0, 'false' => 0],
         ];
     }
@@ -207,8 +207,7 @@ final class LegacyUserPreflightBuilder
         $this->countValue($user->getEmail(), $cohort['attributes']['email']);
         $this->countValue($user->getFirstName(), $cohort['attributes']['firstName']);
         $this->countValue($user->getLastName(), $cohort['attributes']['lastName']);
-        $this->countValue($user->getMobileNumber(), $cohort['attributes']['mobileNumber']);
-        $this->countValue($user->getPhoneNumber(), $cohort['attributes']['phoneNumber']);
+        $this->countExportMobileNumber($user, $cohort['attributes']['mobileNumber'], $cohort['attributes']['mobileNumberSource']);
         $this->countValue($user->getPostNominals(), $cohort['attributes']['postNominals']);
         $this->countValue($user->getServiceNumber(), $cohort['attributes']['serviceNumber']);
         ++$cohort['attributes']['rank'][null === $user->getRank() ? 'missing' : 'present'];
@@ -216,6 +215,26 @@ final class LegacyUserPreflightBuilder
         ++$cohort['attributes']['passwordHash']['' === $user->getPassword() ? 'blank' : 'present'];
         $this->countBoolean($user->getIsShared(), $cohort['attributes']['isShared']);
         ++$cohort['membershipStatuses'][$membershipStatus];
+    }
+
+    private function countExportMobileNumber(User $user, array &$valueCounts, array &$sourceCounts): void
+    {
+        $mobileNumber = $user->getMobileNumber();
+        if (null !== $mobileNumber) {
+            ++$sourceCounts['mobileNumber'];
+            $this->countValue($mobileNumber, $valueCounts);
+            return;
+        }
+
+        $phoneNumber = $user->getPhoneNumber();
+        if (null !== $phoneNumber) {
+            ++$sourceCounts['phoneNumberFallback'];
+            $this->countValue($phoneNumber, $valueCounts);
+            return;
+        }
+
+        ++$sourceCounts['none'];
+        $this->countValue(null, $valueCounts);
     }
 
     private function countOldUid(?int $oldUid, array &$report, array &$oldUids): void
@@ -261,6 +280,8 @@ final class LegacyUserPreflightBuilder
             'ROLE_RESIGNED' => 'resigned',
             'ROLE_DECEASED' => 'deceased',
             'ROLE_LOST' => 'lost',
+            'ROLE_SERVING' => 'regular',
+            'ROLE_RETIRED' => 'retired',
         ] as $role => $status) {
             if (in_array($role, $roles, true)) {
                 return $status;

--- a/api/tests/Unit/Service/LegacyUserPreflightBuilderTest.php
+++ b/api/tests/Unit/Service/LegacyUserPreflightBuilderTest.php
@@ -35,6 +35,7 @@ final class LegacyUserPreflightBuilderTest extends TestCase
         $nonMember->setRoles([]);
         $nonMember->setFirstName('');
         $nonMember->setLastName(null);
+        $nonMember->setPhoneNumber('01234567890');
         $nonMember->setPassword('not-a-supported-hash');
 
         $report = (new LegacyUserPreflightBuilder())->build(
@@ -47,15 +48,19 @@ final class LegacyUserPreflightBuilderTest extends TestCase
         self::assertSame('2026-07-19T14:00:00Z', $report['generatedAt']);
         self::assertSame(2, $report['totalUsers']);
         self::assertSame(['excludedRoleDeleted' => 0, 'includedUsers' => 2], $report['eligibility']);
-        self::assertSame(['active' => 1, 'pending' => 1, 'resigned' => 0, 'deceased' => 0, 'lost' => 0], $report['membershipStatuses']);
+        self::assertSame(['active' => 1, 'pending' => 1, 'resigned' => 0, 'deceased' => 0, 'lost' => 0, 'regular' => 0, 'retired' => 0], $report['membershipStatuses']);
         self::assertSame(['true' => 1, 'false' => 1], $report['hasSubscriptions']);
         self::assertSame(2, $report['attributesByOldUid']['set']['users']);
         self::assertSame(0, $report['attributesByOldUid']['missing']['users']);
         self::assertSame(['null' => 0, 'blank' => 0, 'present' => 2], $report['attributesByOldUid']['set']['attributes']['email']);
         self::assertSame(['null' => 0, 'blank' => 1, 'present' => 1], $report['attributesByOldUid']['set']['attributes']['firstName']);
+        self::assertSame(['null' => 0, 'blank' => 0, 'present' => 2], $report['fieldCompleteness']['mobileNumber']);
+        self::assertSame(['mobileNumber' => 1, 'phoneNumberFallback' => 1, 'none' => 0], $report['mobileNumberSource']);
+        self::assertSame(['null' => 0, 'blank' => 0, 'present' => 2], $report['attributesByOldUid']['set']['attributes']['mobileNumber']);
+        self::assertSame(['mobileNumber' => 1, 'phoneNumberFallback' => 1, 'none' => 0], $report['attributesByOldUid']['set']['attributes']['mobileNumberSource']);
         self::assertSame(['missing' => 1, 'present' => 1], $report['attributesByOldUid']['set']['attributes']['rank']);
         self::assertSame(['empty' => 1, 'present' => 1], $report['attributesByOldUid']['set']['attributes']['roles']);
-        self::assertSame(['active' => 1, 'pending' => 1, 'resigned' => 0, 'deceased' => 0, 'lost' => 0], $report['attributesByOldUid']['set']['membershipStatuses']);
+        self::assertSame(['active' => 1, 'pending' => 1, 'resigned' => 0, 'deceased' => 0, 'lost' => 0, 'regular' => 0, 'retired' => 0], $report['attributesByOldUid']['set']['membershipStatuses']);
         self::assertSame(['true' => 1, 'false' => 1], $report['attributesByOldUid']['set']['hasSubscriptions']);
         self::assertSame(1, $report['emailQuality']['duplicateNormalized']);
         self::assertSame(1, $report['emailQuality']['leadingOrTrailingWhitespace']);
@@ -78,6 +83,7 @@ final class LegacyUserPreflightBuilderTest extends TestCase
         $encoded = json_encode($report, JSON_THROW_ON_ERROR);
         self::assertStringNotContainsString('Member@Example.org', $encoded);
         self::assertStringNotContainsString('07123456789', $encoded);
+        self::assertStringNotContainsString('01234567890', $encoded);
         self::assertStringNotContainsString('$2y$', $encoded);
     }
 
@@ -87,7 +93,7 @@ final class LegacyUserPreflightBuilderTest extends TestCase
         $deleted->setRoles(['ROLE_DELETED', 'ROLE_RESIGNED']);
 
         $resigned = $this->user('00000000-0000-0000-0000-000000000021', 'resigned@example.org', true, true);
-        $resigned->setRoles(['ROLE_LOST', 'ROLE_DECEASED', 'ROLE_RESIGNED']);
+        $resigned->setRoles(['ROLE_RETIRED', 'ROLE_SERVING', 'ROLE_LOST', 'ROLE_DECEASED', 'ROLE_RESIGNED']);
 
         $deceased = $this->user('00000000-0000-0000-0000-000000000022', 'deceased@example.org', true, true);
         $deceased->setRoles(['ROLE_LOST', 'ROLE_DECEASED']);
@@ -95,36 +101,50 @@ final class LegacyUserPreflightBuilderTest extends TestCase
         $lost = $this->user('00000000-0000-0000-0000-000000000023', 'lost@example.org', true, true);
         $lost->setRoles(['ROLE_LOST']);
 
+        $regular = $this->user('00000000-0000-0000-0000-000000000026', 'regular@example.org', true, true);
+        $regular->setRoles(['ROLE_RETIRED', 'ROLE_SERVING']);
+
+        $retired = $this->user('00000000-0000-0000-0000-000000000027', 'retired@example.org', true, true);
+        $retired->setRoles(['ROLE_RETIRED']);
+
         $pending = $this->user('00000000-0000-0000-0000-000000000024', 'pending@example.org', false, true);
+        $pending->setMobileNumber('');
+        $pending->setPhoneNumber('must-not-be-used');
         $active = $this->user('00000000-0000-0000-0000-000000000025', 'active@example.org', true, true);
 
         $report = (new LegacyUserPreflightBuilder())->build(
-            [$deleted, $resigned, $deceased, $lost, $pending, $active],
+            [$deleted, $resigned, $deceased, $lost, $regular, $retired, $pending, $active],
             [],
             new \DateTimeImmutable('2026-07-19T14:00:00+00:00')
         );
 
-        self::assertSame(6, $report['totalUsers']);
-        self::assertSame(['excludedRoleDeleted' => 1, 'includedUsers' => 5], $report['eligibility']);
+        self::assertSame(8, $report['totalUsers']);
+        self::assertSame(['excludedRoleDeleted' => 1, 'includedUsers' => 7], $report['eligibility']);
         self::assertSame([
             'active' => 1,
             'pending' => 1,
             'resigned' => 1,
             'deceased' => 1,
             'lost' => 1,
+            'regular' => 1,
+            'retired' => 1,
         ], $report['membershipStatuses']);
-        self::assertSame(['true' => 0, 'false' => 5], $report['hasSubscriptions']);
+        self::assertSame(['true' => 0, 'false' => 7], $report['hasSubscriptions']);
         self::assertSame(0, $report['attributesByOldUid']['set']['users']);
-        self::assertSame(5, $report['attributesByOldUid']['missing']['users']);
-        self::assertSame(['null' => 0, 'blank' => 0, 'present' => 5], $report['attributesByOldUid']['missing']['attributes']['email']);
+        self::assertSame(7, $report['attributesByOldUid']['missing']['users']);
+        self::assertSame(['null' => 0, 'blank' => 0, 'present' => 7], $report['attributesByOldUid']['missing']['attributes']['email']);
+        self::assertSame(['null' => 6, 'blank' => 1, 'present' => 0], $report['attributesByOldUid']['missing']['attributes']['mobileNumber']);
+        self::assertSame(['mobileNumber' => 1, 'phoneNumberFallback' => 0, 'none' => 6], $report['attributesByOldUid']['missing']['attributes']['mobileNumberSource']);
         self::assertSame([
             'active' => 1,
             'pending' => 1,
             'resigned' => 1,
             'deceased' => 1,
             'lost' => 1,
+            'regular' => 1,
+            'retired' => 1,
         ], $report['attributesByOldUid']['missing']['membershipStatuses']);
-        self::assertSame(['true' => 0, 'false' => 5], $report['attributesByOldUid']['missing']['hasSubscriptions']);
+        self::assertSame(['true' => 0, 'false' => 7], $report['attributesByOldUid']['missing']['hasSubscriptions']);
         self::assertSame(0, $report['emailQuality']['invalid']);
         self::assertSame(0, $report['emailQuality']['missing']);
     }


### PR DESCRIPTION
## Summary

- map `ROLE_SERVING` to `regular` and `ROLE_RETIRED` to `retired` below the existing historical-status precedence
- report both statuses globally and within the `oldUid` cohorts
- treat exported `mobileNumber` as legacy mobile, falling back to legacy phone only when mobile is null
- report derived mobile completeness and source selection globally and by `oldUid` cohort
- remove separate phone-number completeness from the export-facing preflight

## Why

This brings the preflight into line with the agreed destination-ready export transformations rather than mirroring legacy fields directly.

## Validation

- `LegacyUserPreflightBuilderTest`: 2 tests, 49 assertions
- PHP syntax validation
- `git diff --check`

Follow-up to #144. Part of #141.
